### PR TITLE
Fix issue with launching visualizer, atleast on OSX

### DIFF
--- a/miniswarm
+++ b/miniswarm
@@ -321,7 +321,7 @@ deploy_swarm_visualizer() {
   if [[ $(docker ps -qa -f 'Status=exited' -f Name='swarm_visualizer') ]]; then
     docker rm -vf swarm_visualizer > /dev/null
   fi
-  docker run -it -d --name swarm_visualizer -p 5000:8080 -e HOST="$manager_ip" -e PORT=5000 -v /var/run/docker.sock:/var/run/docker.sock manomarks/visualizer
+  docker run -it -d --name swarm_visualizer -p 5000:8080 -e HOST="$manager_ip" -v /var/run/docker.sock:/var/run/docker.sock manomarks/visualizer
   )
   # Wait for it to come up
   wait_for_command "curl -s http://${manager_ip}:5000 -o /dev/null"

--- a/miniswarm
+++ b/miniswarm
@@ -321,7 +321,7 @@ deploy_swarm_visualizer() {
   if [[ $(docker ps -qa -f 'Status=exited' -f Name='swarm_visualizer') ]]; then
     docker rm -vf swarm_visualizer > /dev/null
   fi
-  docker run -it -d --name swarm_visualizer -p 5000:5000 -e HOST="$manager_ip" -e PORT=5000 -v /var/run/docker.sock:/var/run/docker.sock manomarks/visualizer
+  docker run -it -d --name swarm_visualizer -p 5000:8080 -e HOST="$manager_ip" -e PORT=5000 -v /var/run/docker.sock:/var/run/docker.sock manomarks/visualizer
   )
   # Wait for it to come up
   wait_for_command "curl -s http://${manager_ip}:5000 -o /dev/null"


### PR DESCRIPTION
I was getting timeouts when launching visualizer. It was ignoring the PORT Environment variable. Maybe the best way is to pass in the port to publish, i might do it in a future PR. Great little project BTW.